### PR TITLE
Allow setting php package basename

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class icinga::install {
          #package { 'icinga-gui': ensure => installed }
        }
        if ( $icinga::params::gui_type =~ /^(web|both)$/ ) {
-         ensure_packages(["icinga-web","php-soap","php-gd","php-ldap"])
+         ensure_packages(["icinga-web","${icinga::params::php_package_prefix}-soap","${icinga::params::php_package_prefix}-gd","php-ldap"])
          #package { 'icinga-web': ensure => installed }
          #package { ['php-soap','php-gd','php-ldap']: ensure => installed }
        }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class icinga::params (
   $ldap_groupattr = memberOf,
   $ldap_filter_extra = undef,
   $ldap_auth_group = undef,
+  $php_package_basename = 'php',
 ) {
   if $::architecture == 'x86_64' and $::osfamily == 'RedHat' {
     $nagios_plugins = '/usr/lib64/nagios/plugins'


### PR DESCRIPTION
Since the php package basename can be lots of things (like php53u from EPEL)
it makes sense to allow overriding the package basename
