### PR TITLE
Two small fixes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,8 +4,8 @@
 
 class icinga::install {
 
-  $ido_db_server = $::icinga::ido_db_server,
-  $manage_repo   = $::icinga::manage_repo,
+  $ido_db_server = $::icinga::ido_db_server
+  $manage_repo   = $::icinga::manage_repo
   $gui_type      = $::icinga::gui_type
 
   case $::osfamily {

--- a/manifests/nagios_resources.pp
+++ b/manifests/nagios_resources.pp
@@ -5,8 +5,8 @@
 class icinga::nagios_resources (
 ) {
 
-  $icinga_user  = $::icinga::icinga_user,
-  $icinga_group = $::icinga::icinga_group,
+  $icinga_user  = $::icinga::icinga_user
+  $icinga_group = $::icinga::icinga_group
 
   $nagios_resource_files = [
     '/etc/nagios/nagios_command.cfg',

--- a/templates/etc/icinga-web/conf.d/databases.xml.erb
+++ b/templates/etc/icinga-web/conf.d/databases.xml.erb
@@ -16,7 +16,7 @@
     Overwrite the icinga-web database (where users, roles, views, etc are stored 
     -->
     <db:database name="icinga_web" class="AppKitDoctrineDatabase">
-      <ae:parameter name="dsn"><%= @web_db_server %>://<%= @web_db_user %>:<%= @web_db_pass %>@<%= @web_db_host %>:<%- if @web_db_server == 'pgsql' and web_db_port == 3306 -%>5432<%- else -%><%= @web_db_port %><%- end -%>/<%= @web_db_name %></ae:parameter>
+      <ae:parameter name="dsn"><%= @web_db_server %>://<%= @web_db_user %>:<%= @web_db_pass %>@<%= @web_db_host %>:<%- if @web_db_server == 'pgsql' and @web_db_port == 3306 -%>5432<%- else -%><%= @web_db_port %><%- end -%>/<%= @web_db_name %></ae:parameter>
         <ae:parameter name="charset">utf8</ae:parameter>
         <ae:parameter name="manager_attributes">
             <ae:parameter name="Doctrine_Core::ATTR_MODEL_LOADING">CONSERVATIVE</ae:parameter>
@@ -43,7 +43,7 @@
         EXAMPLE (oracle needs icingaOracle as the db driver) 
     -->
     <db:database xmlns="http://agavi.org/agavi/config/parts/databases/1.0" name="icinga" class="IcingaDoctrineDatabase">
-      <ae:parameter name="dsn"><%= @ido_db_server %>://<%= @ido_db_user %>:<%= @ido_db_pass %>@<%= @ido_db_host %>:<%- if @ido_db_server == 'pgsql' and ido_db_port == 3306 -%>5432<%- else -%><%= @ido_db_port %><%- end -%>/<%= @ido_db_name %></ae:parameter>
+      <ae:parameter name="dsn"><%= @ido_db_server %>://<%= @ido_db_user %>:<%= @ido_db_pass %>@<%= @ido_db_host %>:<%- if @ido_db_server == 'pgsql' and @ido_db_port == 3306 -%>5432<%- else -%><%= @ido_db_port %><%- end -%>/<%= @ido_db_name %></ae:parameter>
         <ae:parameter name="prefix">icinga_</ae:parameter>
         <ae:parameter name="charset">utf8</ae:parameter>
         <ae:parameter name="use_retained">true</ae:parameter>


### PR DESCRIPTION
with puppet 3.8.4, future parser, it fails to generate a catalog, because of illegal comma separated list in install.pp as well as in nagios_resources.pp

further, when it parsers the template for the web interface database setup, it's spitting out some warnings to prefix variables with @
